### PR TITLE
Fix shebangs.

### DIFF
--- a/firefox-nightly.spec
+++ b/firefox-nightly.spec
@@ -48,6 +48,7 @@ tar -jxvf nightly.tar.bz2  -C %{_builddir}
 %install
 
 sed -i 's/python/python3/' %{_builddir}/firefox/fix_linux_stack.py
+sed -i 's/python/python3/' %{_builddir}/firefox/fix_stacks.py
 sed -i 's/python/python3/' %{_builddir}/firefox/fix_stack_using_bpsyms.py
 sed -i 's/python/python3/' %{_builddir}/firefox/dmd.py
 


### PR DESCRIPTION
Just an update of #2 !
Mozilla added another file with no explicit shebang.

You should also consider SriRamanujam's fix for this:
```
find %{_builddir} -name '*.py' -exec sed -i -e 's,#!/usr/bin/python,#!/usr/bin/python2,' -e 's,/usr/bin/env python,/usr/bin/env python2,' -s {} \;
```

Maybe updated to python3 ?
```
find %{_builddir} -name '*.py' -exec sed -i -e 's,#!/usr/bin/python,#!/usr/bin/python3,' -e 's,/usr/bin/env python,/usr/bin/env python3,' -s {} \;
```

PS: Weirdly, mock do not check for these :stuck_out_tongue:.